### PR TITLE
Update repo2docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-- repo: https://github.com/ambv/black
-  rev: 19.10b0
+- repo: https://github.com/psf/black
+  rev: 20.8b1
   hooks:
   - id: black
     args: [--target-version=py35]
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.8.4
   hooks:
   - id: flake8
     # default black line length is 88

--- a/repo2shellscript/shellscript.py
+++ b/repo2shellscript/shellscript.py
@@ -63,7 +63,7 @@ if [ -d {p} ]; then
     done
 else
     cp {p} {dest}
-    chown {chown} "$i"
+    chown {chown} "{dest}"
 fi
 """
         else:

--- a/repo2shellscript/shellscript.py
+++ b/repo2shellscript/shellscript.py
@@ -272,10 +272,10 @@ class ShellScriptEngine(ContainerEngine):
             # Set _REPO2SHELLSCRIPT_SRCDIR so that we can reference the source dir
             # in the script
             f.write(
-                f"""\
+                """\
 #!/usr/bin/env bash
 set -eux
-_REPO2SHELLSCRIPT_SRCDIR=$(cd "$( dirname "${{BASH_SOURCE[0]}}" )" && pwd)
+_REPO2SHELLSCRIPT_SRCDIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 
 """
             )

--- a/repo2shellscript/shellscript.py
+++ b/repo2shellscript/shellscript.py
@@ -2,6 +2,7 @@
 from dockerfile_parse import DockerfileParser
 import json
 import os
+import re
 import shlex
 from shutil import copytree
 from string import Template
@@ -40,7 +41,7 @@ def _sudo_user(user, bash, env):
     return sudo
 
 
-def _docker_copy(copy):
+def _docker_copy(copy, chown):
     # Since this is run inside the environment we need to ensure path is absolute.
     # Also need to deal with copying the contents of directories to match Docker.
     paths = shlex.split(copy)
@@ -53,7 +54,26 @@ def _docker_copy(copy):
         p = os.path.join(
             '"${_REPO2SHELLSCRIPT_SRCDIR}"', shlex.quote(paths[n].strip("/"))
         )
-        statement += f"if [ -d {p} ]; then cp -a {p}/* {dest}; else cp {p} {dest}; fi\n"
+        if chown:
+            statement += f"""\
+if [ -d {p} ]; then
+    for i in {p}/*; do
+        cp -a "$i" {dest};
+        chown -R {chown} {dest}/"`basename "$i"`"
+    done
+else
+    cp {p} {dest}
+    chown {chown} "$i"
+fi
+"""
+        else:
+            statement += f"""\
+if [ -d {p} ]; then
+    cp -a {p}/* {dest}
+else
+    cp {p} {dest}
+fi
+"""
     return statement
 
 
@@ -114,7 +134,11 @@ def dockerfile_to_bash(dockerfile, buildargs):
         elif instruction == "CMD":
             cmd = " ".join(shlex.quote(p) for p in json.loads(d["value"]))
         elif instruction == "COPY":
-            statement += _docker_copy(d["value"])
+            m = re.match(r"--chown[=\s+](\S+)\s+(.+)", d["value"])
+            if m:
+                statement += _docker_copy(m.group(2), m.group(1))
+            else:
+                statement += _docker_copy(d["value"], None)
         elif instruction == "ENTRYPOINT":
             entrypoint = " ".join(shlex.quote(p) for p in json.loads(d["value"]))
         elif instruction == "ENV":

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ setuptools.setup(
     # https://github.com/jupyter/repo2docker/pull/848
     install_requires=[
         "dockerfile-parse",
-        "jupyter-repo2docker @ "
-        "git+https://github.com/manics/repo2docker.git@abstractengine",
+        # "jupyter-repo2docker@git+https://github.com/manics/repo2docker.git@abstractengine",
+        "jupyter-repo2docker@git+https://github.com/manics/repo2docker.git@878ff31b9c7c15f0baa41c8bb142997324d0442e",  # noqa: E501
         "importlib_resources;python_version<'3.7'",
     ],
     python_requires=">=3.5",

--- a/tests/reference-outputs/test/Dockerfile
+++ b/tests/reference-outputs/test/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM buildpack-deps:bionic
 
-# avoid prompts from apt
+# Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set up locales properly
@@ -41,8 +41,8 @@ RUN groupadd \
 
 RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
     DISTRO="bionic" && \
-    echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
-    echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
+    echo "deb https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb-src https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
 
 # Base package installs are not super interesting to users, so hide their outputs
 # If install fails for some reason, errors will still be printed
@@ -69,11 +69,11 @@ ENV KERNEL_PYTHON_PREFIX ${NB_PYTHON_PREFIX}
 ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${NPM_DIR}/bin:${PATH}
 # If scripts required during build are present, copy them
 
-COPY <normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
+COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
 
-COPY <normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
+COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
 
-COPY <normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
+COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
 RUN mkdir -p ${NPM_DIR} && \
 chown -R ${NB_USER}:${NB_USER} ${NPM_DIR}
 
@@ -81,7 +81,8 @@ USER ${NB_USER}
 RUN npm config --global set prefix ${NPM_DIR}
 
 USER root
-RUN bash /tmp/install-miniforge.bash && \
+RUN TIMEFORMAT='time: %3R' \
+bash -c 'time /tmp/install-miniforge.bash' && \
 rm /tmp/install-miniforge.bash /tmp/environment.yml
 
 
@@ -90,6 +91,7 @@ rm /tmp/install-miniforge.bash /tmp/environment.yml
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
 WORKDIR ${REPO_DIR}
+RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 # We want to allow two things:
 #   1. If there's a .local/bin directory in the repo, things there
@@ -109,21 +111,18 @@ ENV CONDA_DEFAULT_ENV ${KERNEL_PYTHON_PREFIX}
 # example installing APT packages.
 # If scripts required during build are present, copy them
 
-COPY src/environment.yml ${REPO_DIR}/environment.yml
-USER root
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+COPY --chown=1002:1002 src/environment.yml ${REPO_DIR}/environment.yml
 USER ${NB_USER}
-RUN conda env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && \
-conda clean --all -f -y && \
-conda list -p ${NB_PYTHON_PREFIX}
+RUN TIMEFORMAT='time: %3R' \
+bash -c 'time mamba env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && \
+time mamba clean --all -f -y && \
+mamba list -p ${NB_PYTHON_PREFIX} \
+'
 
 
 
-# Copy and chown stuff. This doubles the size of the repo, because
-# you can't actually copy as USER, only as root! Thanks, Docker!
-USER root
-COPY src/ ${REPO_DIR}
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+# Copy stuff.
+COPY --chown=1002:1002 src/ ${REPO_DIR}
 
 # Run assemble scripts! These will actually turn the specification
 # in the repository into an image.
@@ -135,7 +134,7 @@ RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 LABEL repo2docker.ref="577865357337eb0b562fc747afb9e98b4a7bcacc"
 LABEL repo2docker.repo="https://github.com/binder-examples/conda"
-LABEL repo2docker.version="0.11.0+129.geed8c99"
+LABEL repo2docker.version= <normalised>
 
 # We always want containers to run as non-root
 USER ${NB_USER}

--- a/tests/reference-outputs/test/build_script_files/repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml
+++ b/tests/reference-outputs/test/build_script_files/repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml
@@ -1,5 +1,5 @@
 # AUTO GENERATED FROM environment.py-3.7.yml, DO NOT MANUALLY MODIFY
-# Frozen on 2020-07-25 17:16:14 UTC
+# Frozen on 2021-02-16 14:46:08 UTC
 name: r2d
 channels:
   - conda-forge
@@ -7,110 +7,125 @@ channels:
   - conda-forge/label/broken
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=0_gnu
-  - alembic=1.4.2=pyh9f0ad1d_0
+  - _openmp_mutex=4.5=1_gnu
+  - alembic=1.5.4=pyhd8ed1ab_0
+  - anyio=2.1.0=py37h89c1867_0
+  - argon2-cffi=20.1.0=py37h5e8e339_2
   - async_generator=1.10=py_0
-  - attrs=19.3.0=py_0
+  - attrs=20.3.0=pyhd3deb0d_0
+  - babel=2.9.0=pyhd3deb0d_0
   - backcall=0.2.0=pyh9f0ad1d_0
-  - bleach=3.1.5=pyh9f0ad1d_0
+  - backports=1.0=py_2
+  - backports.functools_lru_cache=1.6.1=py_0
+  - bleach=3.3.0=pyh44b312d_0
   - blinker=1.4=py_1
-  - brotlipy=0.7.0=py37h8f50634_1000
-  - ca-certificates=2020.6.20=hecda079_0
-  - certifi=2020.6.20=py37hc8dfbb8_0
+  - brotlipy=0.7.0=py37h5e8e339_1001
+  - c-ares=1.17.1=h36c2ea0_0
+  - ca-certificates=2020.12.5=ha878542_0
+  - certifi=2020.12.5=py37h89c1867_1
   - certipy=0.1.3=py_0
-  - cffi=1.14.0=py37hd463f26_0
-  - chardet=3.0.4=py37hc8dfbb8_1006
-  - cryptography=3.0=py37hb09aad4_0
+  - cffi=1.14.5=py37hc58025e_0
+  - chardet=4.0.0=py37h89c1867_1
+  - cryptography=3.4.4=py37hf1a17b8_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - entrypoints=0.3=py37hc8dfbb8_1001
+  - entrypoints=0.3=pyhd8ed1ab_1003
   - idna=2.10=pyh9f0ad1d_0
-  - importlib-metadata=1.7.0=py37hc8dfbb8_0
-  - importlib_metadata=1.7.0=0
-  - ipykernel=5.3.4=py37h43977f1_0
-  - ipython=7.16.1=py37h43977f1_0
+  - importlib-metadata=3.4.0=py37h89c1867_0
+  - importlib_metadata=3.4.0=hd8ed1ab_0
+  - ipykernel=5.4.2=py37h888b3d9_0
+  - ipython=7.20.0=py37h888b3d9_2
   - ipython_genutils=0.2.0=py_1
-  - ipywidgets=7.5.1=py_0
-  - jedi=0.17.2=py37hc8dfbb8_0
-  - jinja2=2.11.2=pyh9f0ad1d_0
-  - json5=0.9.4=pyh9f0ad1d_0
-  - jsonschema=3.2.0=py37hc8dfbb8_1
-  - jupyter_client=6.1.6=py_0
-  - jupyter_core=4.6.3=py37hc8dfbb8_1
-  - jupyter_telemetry=0.0.5=py_0
-  - jupyterhub-base=1.1.0=py37_2
-  - jupyterhub-singleuser=1.1.0=py37_2
-  - jupyterlab=2.2.0=py_0
-  - jupyterlab_server=1.2.0=py_0
-  - krb5=1.17.1=hfafb76e_1
-  - ld_impl_linux-64=2.34=h53a641e_7
-  - libcurl=7.71.1=hcdd3856_3
-  - libedit=3.1.20191231=h46ee950_1
-  - libffi=3.2.1=he1b5a44_1007
-  - libgcc-ng=9.2.0=h24d8f2e_2
-  - libgomp=9.2.0=h24d8f2e_2
-  - libsodium=1.0.17=h516909a_0
-  - libssh2=1.9.0=hab1572f_4
-  - libstdcxx-ng=9.2.0=hdf63c60_2
-  - mako=1.1.0=py_0
-  - markupsafe=1.1.1=py37h8f50634_1
-  - mistune=0.8.4=py37h8f50634_1001
+  - ipywidgets=7.6.3=pyhd3deb0d_0
+  - jedi=0.18.0=py37h89c1867_2
+  - jinja2=2.11.3=pyh44b312d_0
+  - json5=0.9.5=pyh9f0ad1d_0
+  - jsonschema=3.2.0=py_2
+  - jupyter-offlinenotebook=0.2.1=pyhd8ed1ab_0
+  - jupyter-resource-usage=0.5.1=pyhd8ed1ab_0
+  - jupyter_client=6.1.11=pyhd8ed1ab_1
+  - jupyter_core=4.7.1=py37h89c1867_0
+  - jupyter_server=1.3.0=py37h89c1867_0
+  - jupyter_telemetry=0.1.0=pyhd8ed1ab_1
+  - jupyterhub-base=1.1.0=py37hc8dfbb8_5
+  - jupyterhub-singleuser=1.1.0=py37hc8dfbb8_5
+  - jupyterlab=3.0.7=pyhd8ed1ab_0
+  - jupyterlab_server=2.2.0=pyhd8ed1ab_0
+  - jupyterlab_widgets=1.0.0=pyhd8ed1ab_1
+  - krb5=1.17.2=h926e7f8_0
+  - ld_impl_linux-64=2.35.1=hea4e1c9_2
+  - libcurl=7.71.1=hcdd3856_8
+  - libedit=3.1.20191231=he28a2e2_2
+  - libev=4.33=h516909a_1
+  - libffi=3.3=h58526e2_2
+  - libgcc-ng=9.3.0=h2828fa1_18
+  - libgomp=9.3.0=h2828fa1_18
+  - libnghttp2=1.43.0=h812cca2_0
+  - libsodium=1.0.18=h36c2ea0_1
+  - libssh2=1.9.0=hab1572f_5
+  - libstdcxx-ng=9.3.0=h6de172a_18
+  - mako=1.1.4=pyh44b312d_0
+  - markupsafe=1.1.1=py37h5e8e339_3
+  - mistune=0.8.4=py37h5e8e339_1003
+  - nbclassic=0.2.6=pyhd8ed1ab_0
   - nbconvert=5.6.1=py37hc8dfbb8_1
-  - nbformat=5.0.7=py_0
-  - nbresuse=0.3.3=py_0
-  - ncurses=6.2=he1b5a44_1
-  - notebook=6.0.3=py37hc8dfbb8_1
+  - nbformat=5.1.2=pyhd8ed1ab_1
+  - ncurses=6.2=h58526e2_4
+  - notebook=6.1.6=py37h89c1867_0
   - nteract_on_jupyter=2.1.3=py_0
   - oauthlib=3.0.1=py_0
-  - openssl=1.1.1g=h516909a_0
-  - packaging=20.4=pyh9f0ad1d_0
+  - openssl=1.1.1i=h7f98852_0
+  - packaging=20.9=pyh44b312d_0
   - pamela=1.0.0=py_0
-  - pandoc=2.10.1=h516909a_0
+  - pandoc=2.11.4=h7f98852_0
   - pandocfilters=1.4.2=py_1
-  - parso=0.7.1=pyh9f0ad1d_0
-  - pexpect=4.8.0=py37hc8dfbb8_1
-  - pickleshare=0.7.5=py37hc8dfbb8_1001
-  - pip=20.1.1=py_1
-  - prometheus_client=0.8.0=pyh9f0ad1d_0
-  - prompt-toolkit=3.0.5=py_1
-  - psutil=5.7.2=py37h8f50634_0
-  - ptyprocess=0.6.0=py_1001
+  - parso=0.8.1=pyhd8ed1ab_0
+  - pexpect=4.8.0=pyh9f0ad1d_2
+  - pickleshare=0.7.5=py_1003
+  - pip=21.0.1=pyhd8ed1ab_0
+  - prometheus_client=0.9.0=pyhd3deb0d_0
+  - prompt-toolkit=3.0.16=pyha770c72_0
+  - psutil=5.8.0=py37h5e8e339_1
+  - ptyprocess=0.7.0=pyhd3deb0d_0
   - pycparser=2.20=pyh9f0ad1d_2
-  - pycurl=7.43.0.5=py37hce7685b_2
-  - pygments=2.6.1=py_0
-  - pyjwt=1.7.1=py_0
-  - pyopenssl=19.1.0=py_1
+  - pycurl=7.43.0.6=py37h88a64d2_1
+  - pygments=2.8.0=pyhd8ed1ab_0
+  - pyjwt=2.0.1=pyhd8ed1ab_0
+  - pyopenssl=20.0.1=pyhd8ed1ab_0
   - pyparsing=2.4.7=pyh9f0ad1d_0
-  - pyrsistent=0.16.0=py37h8f50634_0
-  - pysocks=1.7.1=py37hc8dfbb8_1
-  - python=3.7.8=h6f2ec95_0_cpython
+  - pyrsistent=0.17.3=py37h5e8e339_2
+  - pysocks=1.7.1=py37h89c1867_3
+  - python=3.7.9=hffdb5ce_100_cpython
   - python-dateutil=2.8.1=py_0
   - python-editor=1.0.4=py_0
-  - python-json-logger=0.1.11=py_0
+  - python-json-logger=2.0.1=pyh9f0ad1d_0
   - python_abi=3.7=1_cp37m
-  - pyzmq=19.0.1=py37hac76be4_0
+  - pytz=2021.1=pyhd8ed1ab_0
+  - pyzmq=22.0.3=py37h499b945_0
   - readline=8.0=he28a2e2_2
-  - requests=2.24.0=pyh9f0ad1d_0
-  - ruamel.yaml=0.16.6=py37h8f50634_1
-  - ruamel.yaml.clib=0.2.0=py37h8f50634_1
+  - requests=2.25.1=pyhd3deb0d_0
+  - ruamel.yaml=0.16.12=py37h5e8e339_2
+  - ruamel.yaml.clib=0.2.2=py37h5e8e339_2
   - send2trash=1.5.0=py_0
-  - setuptools=49.2.0=py37hc8dfbb8_0
+  - setuptools=49.6.0=py37h89c1867_3
   - six=1.15.0=pyh9f0ad1d_0
-  - sqlalchemy=1.3.18=py37h8f50634_0
-  - sqlite=3.32.3=hcee41ef_1
-  - terminado=0.8.3=py37hc8dfbb8_1
+  - sniffio=1.2.0=py37h89c1867_1
+  - sqlalchemy=1.3.23=py37h5e8e339_0
+  - sqlite=3.34.0=h74cdb3f_0
+  - terminado=0.9.2=py37h89c1867_0
   - testpath=0.4.4=py_0
-  - tk=8.6.10=hed695b0_0
-  - tornado=6.0.4=py37h8f50634_1
-  - traitlets=4.3.3=py37hc8dfbb8_1
-  - urllib3=1.25.10=py_0
-  - wcwidth=0.2.5=pyh9f0ad1d_0
+  - tk=8.6.10=h21135ba_1
+  - tornado=6.1=py37h5e8e339_1
+  - traitlets=5.0.5=py_0
+  - typing_extensions=3.7.4.3=py_0
+  - urllib3=1.26.3=pyhd8ed1ab_0
+  - wcwidth=0.2.5=pyh9f0ad1d_2
   - webencodings=0.5.1=py_1
-  - wheel=0.34.2=py_1
-  - widgetsnbextension=3.5.1=py37hc8dfbb8_1
+  - wheel=0.36.2=pyhd3deb0d_0
+  - widgetsnbextension=3.5.1=py37h89c1867_4
   - xz=5.2.5=h516909a_1
-  - zeromq=4.3.2=he1b5a44_2
-  - zipp=3.1.0=py_0
-  - zlib=1.2.11=h516909a_1006
+  - zeromq=4.3.4=h9c3ff4c_0
+  - zipp=3.4.0=py_0
+  - zlib=1.2.11=h516909a_1010
 prefix: /opt/conda/envs/r2d
 

--- a/tests/reference-outputs/test/build_script_files/repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash
+++ b/tests/reference-outputs/test/build_script_files/repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash
@@ -1,20 +1,23 @@
 #!/bin/bash
-# This downloads and installs a pinned version of miniconda
+# This downloads and installs a pinned version of miniforge
+# and sets up the base environment
 set -ex
 
-cd $(dirname $0)
-MINIFORGE_VERSION=4.8.2-1
-# SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
-SHA256SUM="4f897e503bd0edfb277524ca5b6a5b14ad818b3198c2f07a36858b7d88c928db"
 
-URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh"
+cd $(dirname $0)
+MINIFORGE_VERSION=4.9.2-2
+MAMBA_VERSION=0.7.4
+# SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
+SHA256SUM="7a7bfaff87680298304a97ba69bcf92f66c810995a7155a2918b99fafb8ca1dc"
+
+URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Mambaforge-${MINIFORGE_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniforge-installer.sh
 
 # make sure we don't do anything funky with user's $HOME
 # since this is run as root
 unset HOME
 
-wget --quiet $URL -O ${INSTALLER_PATH}
+time wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
 # check sha256 checksum
@@ -23,7 +26,7 @@ if ! echo "${SHA256SUM}  ${INSTALLER_PATH}" | sha256sum  --quiet -c -; then
     exit 1
 fi
 
-bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+time bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
 # Preserve behavior of miniconda - packages come from conda-forge + defaults
@@ -39,17 +42,11 @@ echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 # avoid future changes to default channel_priority behavior
 conda config --system --set channel_priority "flexible"
 
+time mamba install -y mamba==${MAMBA_VERSION}
+
 echo "installing notebook env:"
 cat /tmp/environment.yml
-conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
-
-# Install jupyter-offline-notebook to allow users to download notebooks
-# after the server connection has been lost
-# This will install and enable the extension for jupyter notebook
-${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.0
-# and this installs it for lab. Keep going if the lab version is incompatible
-# with the extension
-${NB_PYTHON_PREFIX}/bin/jupyter labextension install jupyter-offlinenotebook || true
+time mamba env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 
 # empty conda history file,
 # which seems to result in some effective pinning of packages in the initial env,
@@ -62,14 +59,14 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
     echo "installing kernel env:"
     cat /tmp/kernel-environment.yml
 
-    conda env create -p ${KERNEL_PYTHON_PREFIX} -f /tmp/kernel-environment.yml
+    time mamba env create -p ${KERNEL_PYTHON_PREFIX} -f /tmp/kernel-environment.yml
     ${KERNEL_PYTHON_PREFIX}/bin/ipython kernel install --prefix "${NB_PYTHON_PREFIX}"
     echo '' > ${KERNEL_PYTHON_PREFIX}/conda-meta/history
-    conda list -p ${KERNEL_PYTHON_PREFIX}
+    mamba list -p ${KERNEL_PYTHON_PREFIX}
 fi
 
 # Clean things out!
-conda clean --all -f -y
+time mamba clean --all -f -y
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
@@ -79,5 +76,5 @@ rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
 
-conda list -n root
-conda list -p ${NB_PYTHON_PREFIX}
+mamba list -n root
+mamba list -p ${NB_PYTHON_PREFIX}

--- a/tests/reference-outputs/test/repo2docker-entrypoint
+++ b/tests/reference-outputs/test/repo2docker-entrypoint
@@ -2,11 +2,23 @@
 # lightest possible entrypoint that ensures that
 # we use a login shell to get a fully configured shell environment
 # (e.g. sourcing /etc/profile.d, ~/.bashrc, and friends)
+
+# Setup a file descriptor (FD) that is connected to a tee process which
+# writes its input to $REPO_DIR/.jupyter-server-log.txt
+# We later use this FD as a place to redirect the output of the actual
+# command to. We can't add `tee` to the command directly as that will prevent
+# the container from exiting when `docker stop` is run.
+# See https://stackoverflow.com/a/55678435
+exec {log_fd}> >(exec tee $REPO_DIR/.jupyter-server-log.txt)
+
 if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
     if [[ ! -x "$R2D_ENTRYPOINT" ]]; then
         chmod u+x "$R2D_ENTRYPOINT"
     fi
-    exec "$R2D_ENTRYPOINT" "$@"
+    exec "$R2D_ENTRYPOINT" "$@" 2>&1 >&"$log_fd"
 else
-    exec "$@"
+    exec "$@" 2>&1 >&"$log_fd"
 fi
+
+# Close the logging output again
+exec {log_fd}>&-

--- a/tests/reference-outputs/test/repo2shellscript-build.bash
+++ b/tests/reference-outputs/test/repo2shellscript-build.bash
@@ -80,7 +80,7 @@ else
 fi
 rm -rf /var/lib/apt/lists/*
 
-# avoid prompts from apt
+# Avoid prompts from apt
 
 # ENV DEBIAN_FRONTEND=noninteractive
 export DEBIAN_FRONTEND=noninteractive
@@ -141,9 +141,9 @@ groupadd         --gid ${NB_UID}         ${NB_USER} &&     useradd         --com
 
 # RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
 #     DISTRO="bionic" && \
-#     echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
-#     echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
-wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - &&     DISTRO="bionic" &&     echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list &&     echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
+#     echo "deb https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
+#     echo "deb-src https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
+wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - &&     DISTRO="bionic" &&     echo "deb https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list &&     echo "deb-src https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
 
 # Base package installs are not super interesting to users, so hide their outputs
 
@@ -189,14 +189,38 @@ export PATH=/srv/conda/envs/notebook/bin:/srv/conda/bin:/srv/npm/bin:/usr/local/
 
 # If scripts required during build are present, copy them
 
-# COPY <normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh * /etc/profile.d/activate-conda.sh; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh; fi
+# COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh ]; then
+    for i in "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh *; do
+        cp -a "$i" /etc/profile.d/activate-conda.sh;
+        chown -R 1002:1002 /etc/profile.d/activate-conda.sh/"`basename "$i"`"
+    done
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
+    chown 1002:1002 "$i"
+fi
 
-# COPY <normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml * /tmp/environment.yml; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml; fi
+# COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml ]; then
+    for i in "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml *; do
+        cp -a "$i" /tmp/environment.yml;
+        chown -R 1002:1002 /tmp/environment.yml/"`basename "$i"`"
+    done
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
+    chown 1002:1002 "$i"
+fi
 
-# COPY <normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash * /tmp/install-miniforge.bash; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash; fi
+# COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash ]; then
+    for i in "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash *; do
+        cp -a "$i" /tmp/install-miniforge.bash;
+        chown -R 1002:1002 /tmp/install-miniforge.bash/"`basename "$i"`"
+    done
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
+    chown 1002:1002 "$i"
+fi
 
 # RUN mkdir -p ${NPM_DIR} && \
 # chown -R ${NB_USER}:${NB_USER} ${NPM_DIR}
@@ -209,9 +233,10 @@ sudo -u ${NB_USER} --preserve-env=DEBIAN_FRONTEND,LC_ALL,LANG,LANGUAGE,SHELL,NB_
 
 # USER root
 
-# RUN bash /tmp/install-miniforge.bash && \
+# RUN TIMEFORMAT='time: %3R' \
+# bash -c 'time /tmp/install-miniforge.bash' && \
 # rm /tmp/install-miniforge.bash /tmp/environment.yml
-bash /tmp/install-miniforge.bash && rm /tmp/install-miniforge.bash /tmp/environment.yml
+TIMEFORMAT='time: %3R' bash -c 'time /tmp/install-miniforge.bash' && rm /tmp/install-miniforge.bash /tmp/environment.yml
 
 # Allow target path repo is cloned to be configurable
 
@@ -223,6 +248,9 @@ export REPO_DIR=/home/test
 
 # WORKDIR ${REPO_DIR}
 cd ${REPO_DIR}
+
+# RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
+chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 # We want to allow two things:
 
@@ -258,32 +286,38 @@ export CONDA_DEFAULT_ENV=/srv/conda/envs/notebook
 
 # If scripts required during build are present, copy them
 
-# COPY src/environment.yml ${REPO_DIR}/environment.yml
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml/* ${REPO_DIR}/environment.yml; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ${REPO_DIR}/environment.yml; fi
-
-# USER root
-
-# RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
-chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+# COPY --chown=1002:1002 src/environment.yml ${REPO_DIR}/environment.yml
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ]; then
+    for i in "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml/*; do
+        cp -a "$i" ${REPO_DIR}/environment.yml;
+        chown -R 1002:1002 ${REPO_DIR}/environment.yml/"`basename "$i"`"
+    done
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ${REPO_DIR}/environment.yml
+    chown 1002:1002 "$i"
+fi
 
 # USER ${NB_USER}
 
-# RUN conda env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && \
-# conda clean --all -f -y && \
-# conda list -p ${NB_PYTHON_PREFIX}
-sudo -u ${NB_USER} --preserve-env=DEBIAN_FRONTEND,LC_ALL,LANG,LANGUAGE,SHELL,NB_USER,NB_UID,USER,HOME,APP_BASE,NPM_DIR,NPM_CONFIG_GLOBALCONFIG,CONDA_DIR,NB_PYTHON_PREFIX,KERNEL_PYTHON_PREFIX,PATH,REPO_DIR,CONDA_DEFAULT_ENV bash -c 'conda env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && conda clean --all -f -y && conda list -p ${NB_PYTHON_PREFIX}'
+# RUN TIMEFORMAT='time: %3R' \
+# bash -c 'time mamba env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && \
+# time mamba clean --all -f -y && \
+# mamba list -p ${NB_PYTHON_PREFIX} \
+# '
+sudo -u ${NB_USER} --preserve-env=DEBIAN_FRONTEND,LC_ALL,LANG,LANGUAGE,SHELL,NB_USER,NB_UID,USER,HOME,APP_BASE,NPM_DIR,NPM_CONFIG_GLOBALCONFIG,CONDA_DIR,NB_PYTHON_PREFIX,KERNEL_PYTHON_PREFIX,PATH,REPO_DIR,CONDA_DEFAULT_ENV bash -c 'TIMEFORMAT='"'"'time: %3R'"'"' bash -c '"'"'time mamba env update -p ${NB_PYTHON_PREFIX} -f "environment.yml" && time mamba clean --all -f -y && mamba list -p ${NB_PYTHON_PREFIX} '"'"''
 
-# Copy and chown stuff. This doubles the size of the repo, because
+# Copy stuff.
 
-# you can't actually copy as USER, only as root! Thanks, Docker!
-
-# USER root
-
-# COPY src/ ${REPO_DIR}
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/src/* ${REPO_DIR}; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src ${REPO_DIR}; fi
-
-# RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
-chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+# COPY --chown=1002:1002 src/ ${REPO_DIR}
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src ]; then
+    for i in "${_REPO2SHELLSCRIPT_SRCDIR}"/src/*; do
+        cp -a "$i" ${REPO_DIR};
+        chown -R 1002:1002 ${REPO_DIR}/"`basename "$i"`"
+    done
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src ${REPO_DIR}
+    chown 1002:1002 "$i"
+fi
 
 # Run assemble scripts! These will actually turn the specification
 
@@ -299,7 +333,7 @@ chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 # LABEL repo2docker.repo="https://github.com/binder-examples/conda"
 
-# LABEL repo2docker.version="0.11.0+129.geed8c99"
+# LABEL repo2docker.version= <normalised>
 
 # We always want containers to run as non-root
 
@@ -310,7 +344,11 @@ chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 # Add entrypoint
 
 # COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
-if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint ]; then cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint/* /usr/local/bin/repo2docker-entrypoint; else cp "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint; fi
+if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint ]; then
+    cp -a "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint/* /usr/local/bin/repo2docker-entrypoint
+else
+    cp "${_REPO2SHELLSCRIPT_SRCDIR}"/repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
+fi
 
 # ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 

--- a/tests/reference-outputs/test/repo2shellscript-build.bash
+++ b/tests/reference-outputs/test/repo2shellscript-build.bash
@@ -197,7 +197,7 @@ if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fcon
     done
 else
     cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2factivate-2dconda-2esh /etc/profile.d/activate-conda.sh
-    chown 1002:1002 "$i"
+    chown 1002:1002 "/etc/profile.d/activate-conda.sh"
 fi
 
 # COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
@@ -208,7 +208,7 @@ if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fcon
     done
 else
     cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2fenvironment-2efrozen-2eyml /tmp/environment.yml
-    chown 1002:1002 "$i"
+    chown 1002:1002 "/tmp/environment.yml"
 fi
 
 # COPY --chown=1002:1002 <normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
@@ -219,7 +219,7 @@ if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fcon
     done
 else
     cp "${_REPO2SHELLSCRIPT_SRCDIR}"/<normalised>repo2docker-2fbuildpacks-2fconda-2finstall-2dminiforge-2ebash /tmp/install-miniforge.bash
-    chown 1002:1002 "$i"
+    chown 1002:1002 "/tmp/install-miniforge.bash"
 fi
 
 # RUN mkdir -p ${NPM_DIR} && \
@@ -294,7 +294,7 @@ if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ]; then
     done
 else
     cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src/environment.yml ${REPO_DIR}/environment.yml
-    chown 1002:1002 "$i"
+    chown 1002:1002 "${REPO_DIR}/environment.yml"
 fi
 
 # USER ${NB_USER}
@@ -316,7 +316,7 @@ if [ -d "${_REPO2SHELLSCRIPT_SRCDIR}"/src ]; then
     done
 else
     cp "${_REPO2SHELLSCRIPT_SRCDIR}"/src ${REPO_DIR}
-    chown 1002:1002 "$i"
+    chown 1002:1002 "${REPO_DIR}"
 fi
 
 # Run assemble scripts! These will actually turn the specification

--- a/tests/test_repo2shellscript.py
+++ b/tests/test_repo2shellscript.py
@@ -54,7 +54,7 @@ def test_compare(tmp_path):
     # Normalise the outputs in-place
     for o in outputs:
         normalised_lines = list(_normalise_build_script(o.read_text().splitlines()))
-        o.write_text('\n'.join(normalised_lines) + '\n')
+        o.write_text("\n".join(normalised_lines) + "\n")
 
     # To update reference-outputs/test/:
     # print(tmp_path)

--- a/tests/test_repo2shellscript.py
+++ b/tests/test_repo2shellscript.py
@@ -16,10 +16,10 @@ def _normalise_build_script(lines):
     for line in lines:
         line = re.sub(
             r"build_script_files/\S+-2fsite-2dpackages-2f(\S+)-\w+(\s+|/)",
-            "<normalised>\\1 ",
+            r"<normalised>\1 ",
             line,
         )
-        line = re.sub(r"(LABEL repo2docker.version=)\S+", r"\\1 <normalised>", line)
+        line = re.sub(r"(LABEL repo2docker.version=)\S+", r"\1 <normalised>", line)
         yield line
 
 
@@ -51,6 +51,14 @@ def test_compare(tmp_path):
         Path(__file__).parent / "reference-outputs"
     )
     outputs, relative_outputs = _recursive_filelist(tmp_path)
+    # Normalise the outputs in-place
+    for o in outputs:
+        normalised_lines = list(_normalise_build_script(o.read_text().splitlines()))
+        o.write_text('\n'.join(normalised_lines) + '\n')
+
+    # To update reference-outputs/test/:
+    # print(tmp_path)
+    # And copy those files, updating as necessary
 
     assert sorted(relative_files) == sorted(relative_outputs)
     for f, o in zip(sorted(files), sorted(outputs)):


### PR DESCRIPTION
https://github.com/manics/repo2docker/tree/abstractengine was updated to merge in the repo2docker master, which means the tests were broken since the reference outputs were changed. This PR:
- Updates to the current `abstractengine` engine branch and pins the commit in setup.py to https://github.com/manics/repo2docker/tree/878ff31b9c7c15f0baa41c8bb142997324d0442e
- Updates the reference outputs used for comparisons
