### PR TITLE
repo2docker: master changed to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It does not build a container image, instead you should take the output and use 
 
 This plugin is still in development and relies on [a new feature of repo2docker](https://github.com/jupyter/repo2docker/pull/848).
 
-    pip install -U git+https://github.com/jupyterhub/repo2docker.git@master
+    pip install -U git+https://github.com/jupyterhub/repo2docker.git@main
     pip install -U git+https://github.com/manics/repo2shellscript.git@main
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     # https://github.com/jupyter/repo2docker/pull/848 was merged!
     install_requires=[
         "dockerfile-parse",
-        "jupyter-repo2docker@git+https://github.com/jupyterhub/repo2docker.git@master",  # noqa: E501
+        "jupyter-repo2docker@git+https://github.com/jupyterhub/repo2docker.git@main",  # noqa: E501
         "importlib_resources;python_version<'3.7'",
     ],
     python_requires=">=3.5",


### PR DESCRIPTION
repo2docker `master` branch was renamed to `main`: https://github.com/jupyterhub/repo2docker/pull/1068