### PR TITLE
Fix arg env handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="repo2shellscript",
     # https://github.com/jupyter/repo2docker/pull/848 was merged!
     install_requires=[
-        "dockerfile-parse",
+        "dockerfile-parse>=2,<3",
         "jupyter-repo2docker>=2022.02.0",
         "importlib_resources;python_version<'3.7'",
     ],

--- a/tests/reference-outputs/test/repo2shellscript-build.bash
+++ b/tests/reference-outputs/test/repo2shellscript-build.bash
@@ -307,7 +307,7 @@ fi
 # time ${MAMBA_EXE} clean --all -f -y && \
 # ${MAMBA_EXE} list -p ${NB_PYTHON_PREFIX} \
 # '
-sudo -u ${NB_USER} --preserve-env=DEBIAN_FRONTEND,LC_ALL,LANG,LANGUAGE,SHELL,NB_USER,NB_UID,USER,HOME,APP_BASE,CONDA_DIR,NB_PYTHON_PREFIX,NPM_DIR,NPM_CONFIG_GLOBALCONFIG,NB_ENVIRONMENT_FILE,MAMBA_ROOT_PREFIX,MAMBA_EXE,KERNEL_PYTHON_PREFIX,PATH,REPO_DIR,CONDA_DEFAULT_ENV bash -c 'TIMEFORMAT='"'"'time: %3R'"'"' bash -c '"'"'time ${MAMBA_EXE} env update -p ${NB_PYTHON_PREFIX} --file "environment.yml" && time ${MAMBA_EXE} clean --all -f -y && ${MAMBA_EXE} list -p ${NB_PYTHON_PREFIX} '"'"''
+sudo -u test --preserve-env=PATH,DEBIAN_FRONTEND,LC_ALL,LANG,LANGUAGE,SHELL,NB_USER,NB_UID,USER,HOME,APP_BASE,CONDA_DIR,NB_PYTHON_PREFIX,NPM_DIR,NPM_CONFIG_GLOBALCONFIG,NB_ENVIRONMENT_FILE,MAMBA_ROOT_PREFIX,MAMBA_EXE,KERNEL_PYTHON_PREFIX,REPO_DIR,CONDA_DEFAULT_ENV bash -c 'TIMEFORMAT='"'"'time: %3R'"'"' bash -c '"'"'time ${MAMBA_EXE} env update -p ${NB_PYTHON_PREFIX} --file "environment.yml" && time ${MAMBA_EXE} clean --all -f -y && ${MAMBA_EXE} list -p ${NB_PYTHON_PREFIX} '"'"''
 
 # ensure root user after preassemble scripts
 

--- a/tests/reference-outputs/test/repo2shellscript-start.bash
+++ b/tests/reference-outputs/test/repo2shellscript-start.bash
@@ -4,6 +4,7 @@ if [ $(id -un) != test ]; then
     echo ERROR: Must be run as user test
     exit 1
 fi
+export PATH=/home/test/.local/bin:/home/test/.local/bin:/srv/conda/envs/notebook/bin:/srv/conda/bin:/srv/npm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export DEBIAN_FRONTEND=noninteractive
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
@@ -20,7 +21,6 @@ export NB_ENVIRONMENT_FILE=/tmp/env/environment.lock
 export MAMBA_ROOT_PREFIX=/srv/conda
 export MAMBA_EXE=/srv/conda/bin/mamba
 export KERNEL_PYTHON_PREFIX=/srv/conda/envs/notebook
-export PATH=/home/test/.local/bin:/home/test/.local/bin:/srv/conda/envs/notebook/bin:/srv/conda/bin:/srv/npm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export REPO_DIR=/home/test
 export CONDA_DEFAULT_ENV=/srv/conda/envs/notebook
 export PYTHONUNBUFFERED=1

--- a/tests/reference-outputs/test/repo2shellscript.service
+++ b/tests/reference-outputs/test/repo2shellscript.service
@@ -5,6 +5,7 @@ Description=repo2shellscript
 User=test
 Restart=always
 RestartSec=10
+Environment='PATH=/home/test/.local/bin:/home/test/.local/bin:/srv/conda/envs/notebook/bin:/srv/conda/bin:/srv/npm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 Environment='DEBIAN_FRONTEND=noninteractive'
 Environment='LC_ALL=en_US.UTF-8'
 Environment='LANG=en_US.UTF-8'
@@ -21,7 +22,6 @@ Environment='NB_ENVIRONMENT_FILE=/tmp/env/environment.lock'
 Environment='MAMBA_ROOT_PREFIX=/srv/conda'
 Environment='MAMBA_EXE=/srv/conda/bin/mamba'
 Environment='KERNEL_PYTHON_PREFIX=/srv/conda/envs/notebook'
-Environment='PATH=/home/test/.local/bin:/home/test/.local/bin:/srv/conda/envs/notebook/bin:/srv/conda/bin:/srv/npm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 Environment='REPO_DIR=/home/test'
 Environment='CONDA_DEFAULT_ENV=/srv/conda/envs/notebook'
 Environment='PYTHONUNBUFFERED=1'

--- a/tests/test_repo2shellscript.py
+++ b/tests/test_repo2shellscript.py
@@ -23,7 +23,7 @@ def _recursive_filelist(d):
 def _normalise_build_script(lines):
     for line in lines:
         line = re.sub(
-            r"build_script_files/\S+-2fsite-2dpackages-2f(\S+)-\w+(\s+|/)",
+            r"build_script_files/\S+-2f(repo2docker-2fbuildpacks-2f\S+)-\w+(\s+|/)",
             r"<normalised>\1 ",
             line,
         )
@@ -51,7 +51,7 @@ def test_compare(tmp_path):
     # Normalise filenames under build_script_files
     for build_script in (tmp_path / "test" / "build_script_files").iterdir():
         normalised_name = re.match(
-            r"^.+-2fsite-2dpackages-2f(.+)-\w+$", build_script.name
+            r"^.+-2f(repo2docker-2fbuildpacks-2f.+)-\w+$", build_script.name
         ).group(1)
         build_script.rename(build_script.parent / normalised_name)
 


### PR DESCRIPTION
Some of the ENV statements in repo2docker set multiple variables instead of one per line, e.g. https://github.com/jupyterhub/repo2docker/blob/fabf178d0b04808d287caa40c99802a057d824f8/repo2docker/buildpacks/base.py#L31-L33

dockerfile-parse can handle these, and also has limited supported for expanding some vars.
